### PR TITLE
Adding port checking on values inpute

### DIFF
--- a/src/checker/checker.go
+++ b/src/checker/checker.go
@@ -2,7 +2,6 @@ package checker
 
 import (
 	"checks/kubernetes/services/ports"
-	"fmt"
 
 	"k8s.io/client-go/kubernetes"
 )
@@ -32,7 +31,6 @@ func New(valuesYaml string, clientSet *kubernetes.Clientset, ttype string, name 
 
 // Run - runner
 func (c Check) Run() results {
-	fmt.Println("Starting runner ")
 
 	var returnResults results
 

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -51,7 +51,7 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 	}
 
 	if v.Values.Port == 0 {
-		return errors.New("Check values: invalid `Port`")
+		return errors.New("Check values: no `Port` set")
 	}
 
 	if v.Values.Port < 1 || v.Values.Port > 65353 {

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -47,7 +47,7 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 	}
 
 	if v.Values.ServiceName == "" {
-		return errors.New("Check values: invalid `ServiceName`")
+		return errors.New("Check values: no `ServiceName` set")
 	}
 
 	if v.Values.Port == 0 {

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -54,6 +54,10 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 		return errors.New("Check values: invalid `Port`")
 	}
 
+	if v.Values.Port < 1 || v.Values.Port > 65353 {
+		return errors.New("Check values: invalid `Port` range")
+	}
+
 	return nil
 }
 

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -72,15 +72,15 @@ func (i inputs) DoesPortExist() Results {
 		Message: "Port not found: " + fmt.Sprint(values.Values.Port),
 	}
 
-	parseFailure := false
+	didValuesParse := false
 
 	err := doesPortExistParse(i.valuesYaml, &values)
 	if err != nil {
-		parseFailure = true
+		didValuesParse = true
 		checkResult.Message = fmt.Sprintf("%v", err)
 	}
 
-	if !parseFailure {
+	if !didValuesParse {
 		// Run kube stuff
 		services, err := kubeClientSet.CoreV1().Services(i.namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
@@ -90,11 +90,9 @@ func (i inputs) DoesPortExist() Results {
 		for _, aService := range services.Items {
 
 			if aService.ObjectMeta.Name == values.Values.ServiceName {
-				fmt.Println("Found service: " + aService.ObjectMeta.Name)
 
 				for _, port := range aService.Spec.Ports {
 					if port.Port == values.Values.Port {
-						fmt.Println("Found port: " + fmt.Sprint(values.Values.Port))
 
 						checkResult.DidPass = true
 						checkResult.Message = "Port found: " + fmt.Sprint(values.Values.Port)

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -50,12 +50,8 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 		return errors.New("Check values: no `ServiceName` set")
 	}
 
-	if v.Values.Port == 0 {
-		return errors.New("Check values: no `Port` set")
-	}
-
 	if v.Values.Port < 1 || v.Values.Port > 65353 {
-		return errors.New("Check values: invalid `Port` range")
+		return errors.New("Check values: invalid `Port` specified, allowed range (1 - 65353)")
 	}
 
 	return nil

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -46,8 +46,6 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 		log.Fatalf("Unmarshal: %v", err)
 	}
 
-	// Probably have to check if ServiceName even exist first!!
-
 	if v.Values.ServiceName == "" {
 		return errors.New("Check values: invalid `ServiceName`")
 	}

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -38,12 +39,32 @@ type doesPortExistStruct struct {
 	} `yaml:"values"`
 }
 
+func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
+
+	err := yaml.Unmarshal([]byte(valuesYaml), &v)
+	if err != nil {
+		log.Fatalf("Unmarshal: %v", err)
+	}
+
+	// Probably have to check if ServiceName even exist first!!
+
+	if v.Values.ServiceName == "" {
+		return errors.New("Check values: invalid `ServiceName`")
+	}
+
+	if v.Values.Port == 0 {
+		return errors.New("Check values: invalid `Port`")
+	}
+
+	return nil
+}
+
 // DoesPortExist DoesPortExist
 func (i inputs) DoesPortExist() Results {
 
 	var values doesPortExistStruct
 
-	err := yaml.Unmarshal([]byte(i.valuesYaml), &values)
+	err := doesPortExistParse(i.valuesYaml, &values)
 	if err != nil {
 		log.Fatalf("Unmarshal: %v", err)
 	}

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -49,10 +49,6 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 		return errors.New("Check values: no `ServiceName` set")
 	}
 
-	if v.Values.Port == 0 {
-		return errors.New("Check values: no `Port` set")
-	}
-
 	if v.Values.Port < 1 || v.Values.Port > 65353 {
 		return errors.New("Check values: invalid `Port` specified, allowed range (1 - 65353)")
 	}

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -43,7 +43,7 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 
 	err := yaml.Unmarshal([]byte(valuesYaml), &v)
 	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
+		return errors.New("YAML Parse Error: "+err)
 	}
 
 	if v.Values.ServiceName == "" {

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +42,15 @@ func doesPortExistParse(valuesYaml string, v *doesPortExistStruct) error {
 
 	err := yaml.Unmarshal([]byte(valuesYaml), &v)
 	if err != nil {
-		return errors.New("YAML Parse Error: "+err)
+		return errors.New(fmt.Sprintf("YAML Parse Error: %v", err))
 	}
 
 	if v.Values.ServiceName == "" {
 		return errors.New("Check values: no `ServiceName` set")
+	}
+
+	if v.Values.Port == 0 {
+		return errors.New("Check values: no `Port` set")
 	}
 
 	if v.Values.Port < 1 || v.Values.Port > 65353 {

--- a/src/checks/kubernetes/services/ports/ports.go
+++ b/src/checks/kubernetes/services/ports/ports.go
@@ -64,7 +64,7 @@ func (i inputs) DoesPortExist() Results {
 
 	err := doesPortExistParse(i.valuesYaml, &values)
 	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
+		log.Fatalf("Parse Error: %v", err)
 	}
 
 	// Set initial check results

--- a/src/checks/kubernetes/services/ports/ports_test.go
+++ b/src/checks/kubernetes/services/ports/ports_test.go
@@ -36,7 +36,23 @@ func Test_doesPortExistParse(t *testing.T) {
 				valuesYaml: "values:\n  serviceName: healthapp-caregaps",
 				v:          &doesPortExistStruct{},
 			},
-			wantErr: false,
+			wantErr: true,
+		},
+		{
+			name: "test4 - invalid port range high",
+			args: args{
+				valuesYaml: "values:\n  serviceName: healthapp-caregaps\n  port: 65354",
+				v:          &doesPortExistStruct{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test4 - invalid port range high",
+			args: args{
+				valuesYaml: "values:\n  serviceName: healthapp-caregaps\n  port: -1",
+				v:          &doesPortExistStruct{},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/src/checks/kubernetes/services/ports/ports_test.go
+++ b/src/checks/kubernetes/services/ports/ports_test.go
@@ -1,0 +1,49 @@
+package ports
+
+import (
+	"testing"
+)
+
+func Test_doesPortExistParse(t *testing.T) {
+	type args struct {
+		valuesYaml string
+		v          *doesPortExistStruct
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test1 - success",
+			args: args{
+				valuesYaml: "values:\n  serviceName: healthapp-caregaps\n  port: 20014",
+				v:          &doesPortExistStruct{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test2 - no serviceName param present",
+			args: args{
+				valuesYaml: "values:\n  port: 20014",
+				v:          &doesPortExistStruct{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test3 - no port param present",
+			args: args{
+				valuesYaml: "values:\n  serviceName: healthapp-caregaps",
+				v:          &doesPortExistStruct{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := doesPortExistParse(tt.args.valuesYaml, tt.args.v); (err != nil) != tt.wantErr {
+				t.Errorf("doesPortExistParse() name = %v, error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A check has it's own unique values for whatever it is checking.  This add is to make sure that those values are present or it will return an error to the user:  https://github.com/anthem-ai/kubernetes-state-checker/blob/main/src/cmd/conf.yaml#L11-L13

* Adding checks for the input values
* Added a unit test for the ports check