### PR TITLE
Unit test updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ go get k8s.io/apimachinery/pkg/apis/meta/v1
 go get k8s.io/client-go/kubernetes
 go get k8s.io/client-go/tools/clientcmd
 go get k8s.io/client-go/util/homedir
+go get github.com/evanphx/json-patch
+go get k8s.io/kube-openapi/pkg/util/proto
 ```
 
 ## Kubeconfig

--- a/src/checker/checker.go
+++ b/src/checker/checker.go
@@ -37,8 +37,8 @@ func (c Check) Run() results {
 	switch c.Ttype {
 
 	case "serviceChecks":
-		check := services.New(c.valuesYaml, kubeClientSet, c.Name, c.Namespace)
-		r := check.GeneralCheck()
+		check := services.New(c.valuesYaml, c.Name, c.Namespace)
+		r := check.GeneralCheck(kubeClientSet)
 
 		returnResults = results{
 			DidPass: r.DidPass,

--- a/src/checks/kubernetes/services/service.go
+++ b/src/checks/kubernetes/services/service.go
@@ -141,10 +141,9 @@ func (i inputs) GeneralCheck(kubeClientSet kubernetes.Interface) Results {
 				if values.Values.ChecksEnabled.Ports {
 					for _, port := range aService.Spec.Ports {
 						if port.Port != values.Values.Port {
-
-							checkResult.DidPass = false
 							checkResult.Message += "* Port NOT found: " + fmt.Sprint(values.Values.Port) + "\n"
 						} else {
+							checkResult.DidPass = true
 							checkResult.Message += "* Port found: " + fmt.Sprint(values.Values.Port) + "\n"
 						}
 					}

--- a/src/checks/kubernetes/services/service_test.go
+++ b/src/checks/kubernetes/services/service_test.go
@@ -109,7 +109,7 @@ func Test_inputs_GeneralCheck(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 		{
-			name: "Checking clusterIP",
+			name: "Checking clusterIP (positive)",
 			fields: fields{
 				checkName:  "check1",
 				namespace:  "ns1",
@@ -139,7 +139,7 @@ func Test_inputs_GeneralCheck(t *testing.T) {
 		},
 		// TODO: Fix this test: The endpoint k8s fake info doesnt show up.  The endpoint data is in the second k8s call.  Not sure why
 		// {
-		// 	name: "Checking Endpoints",
+		// 	name: "Checking Endpoints (positive)",
 		// 	fields: fields{
 		// 		checkName:  "check2",
 		// 		namespace:  "ns1",
@@ -185,7 +185,7 @@ func Test_inputs_GeneralCheck(t *testing.T) {
 		// 	},
 		// },
 		{
-			name: "Checking ports",
+			name: "Checking ports (positive)",
 			fields: fields{
 				checkName:  "check3",
 				namespace:  "ns1",

--- a/src/checks/kubernetes/services/service_test.go
+++ b/src/checks/kubernetes/services/service_test.go
@@ -116,6 +116,7 @@ func Test_inputs_GeneralCheck(t *testing.T) {
 				valuesYaml: "values:\n  serviceName: service1\n  port: 20014\n  checksEnabled:\n    clusterIP: true",
 			},
 			args: args{
+				// Doc/example: https://gianarb.it/blog/unit-testing-kubernetes-client-in-go
 				kubeClientSet: fake.NewSimpleClientset(&v1.ServiceList{
 					Items: []v1.Service{
 						{

--- a/src/checks/kubernetes/services/service_test.go
+++ b/src/checks/kubernetes/services/service_test.go
@@ -1,7 +1,13 @@
 package services
 
 import (
+	"reflect"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_serviceParse(t *testing.T) {
@@ -59,6 +65,87 @@ func Test_serviceParse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := serviceParse(tt.args.valuesYaml, tt.args.v); (err != nil) != tt.wantErr {
 				t.Errorf("serviceParse() name = %v, error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	type args struct {
+		valuesYaml string
+		checkName  string
+		namespace  string
+	}
+	tests := []struct {
+		name string
+		args args
+		want inputs
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.args.valuesYaml, tt.args.checkName, tt.args.namespace); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_inputs_GeneralCheck(t *testing.T) {
+	type fields struct {
+		valuesYaml string
+		checkName  string
+		namespace  string
+	}
+	type args struct {
+		kubeClientSet kubernetes.Interface
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   Results
+	}{
+		// TODO: Add test cases.
+		{
+			name: "test1",
+			fields: fields{
+				checkName:  "check1",
+				namespace:  "ns1",
+				valuesYaml: "values:\n  serviceName: service1\n  port: 20014\n  checksEnabled:\n    clusterIP: true",
+			},
+			args: args{
+				kubeClientSet: fake.NewSimpleClientset(&v1.ServiceList{
+					Items: []v1.Service{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "service1",
+								Namespace:   "ns1",
+								Annotations: map[string]string{},
+							},
+							Spec: v1.ServiceSpec{
+								ClusterIP: "1.1.1.1",
+							},
+						},
+					},
+				}),
+			},
+			want: Results{
+				DidPass: true,
+				Message: "* ClusterIP Found\n",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := inputs{
+				valuesYaml: tt.fields.valuesYaml,
+				checkName:  tt.fields.checkName,
+				namespace:  tt.fields.namespace,
+			}
+			if got := i.GeneralCheck(tt.args.kubeClientSet); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("inputs.GeneralCheck() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/src/checks/kubernetes/services/service_test.go
+++ b/src/checks/kubernetes/services/service_test.go
@@ -109,7 +109,7 @@ func Test_inputs_GeneralCheck(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 		{
-			name: "test1",
+			name: "Checking clusterIP",
 			fields: fields{
 				checkName:  "check1",
 				namespace:  "ns1",

--- a/src/checks/kubernetes/services/service_test.go
+++ b/src/checks/kubernetes/services/service_test.go
@@ -137,6 +137,87 @@ func Test_inputs_GeneralCheck(t *testing.T) {
 				Message: "* ClusterIP Found\n",
 			},
 		},
+		// TODO: Fix this test: The endpoint k8s fake info doesnt show up.  The endpoint data is in the second k8s call.  Not sure why
+		// {
+		// 	name: "Checking Endpoints",
+		// 	fields: fields{
+		// 		checkName:  "check2",
+		// 		namespace:  "ns1",
+		// 		valuesYaml: "values:\n  serviceName: service1\n  port: 20014\n  checksEnabled:\n    endpoints: true",
+		// 	},
+		// 	args: args{
+		// 		// Doc/example: https://gianarb.it/blog/unit-testing-kubernetes-client-in-go
+		// 		kubeClientSet: fake.NewSimpleClientset(&v1.EndpointsList{
+		// 			Items: []v1.Endpoints{
+		// 				{
+		// 					ObjectMeta: metav1.ObjectMeta{
+		// 						Name: "service1",
+		// 					},
+		// 					Subsets: []v1.EndpointSubset{
+		// 						{
+		// 							Addresses: []v1.EndpointAddress{
+		// 								{
+		// 									IP: "1.1.1.1",
+		// 								},
+		// 							},
+		// 						},
+		// 					},
+		// 				},
+		// 			},
+		// 		}, &v1.ServiceList{
+		// 			Items: []v1.Service{
+		// 				{
+		// 					ObjectMeta: metav1.ObjectMeta{
+		// 						Name:        "service1",
+		// 						Namespace:   "ns1",
+		// 						Annotations: map[string]string{},
+		// 					},
+		// 					Spec: v1.ServiceSpec{
+		// 						ClusterIP: "1.1.1.1",
+		// 					},
+		// 				},
+		// 			},
+		// 		}),
+		// 	},
+		// 	want: Results{
+		// 		DidPass: true,
+		// 		Message: "* ClusterIP Found\n",
+		// 	},
+		// },
+		{
+			name: "Checking ports",
+			fields: fields{
+				checkName:  "check3",
+				namespace:  "ns1",
+				valuesYaml: "values:\n  serviceName: service1\n  port: 20014\n  checksEnabled:\n    ports: true",
+			},
+			args: args{
+				// Doc/example: https://gianarb.it/blog/unit-testing-kubernetes-client-in-go
+				kubeClientSet: fake.NewSimpleClientset(&v1.ServiceList{
+					Items: []v1.Service{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "service1",
+								Namespace:   "ns1",
+								Annotations: map[string]string{},
+							},
+							Spec: v1.ServiceSpec{
+								ClusterIP: "1.1.1.1",
+								Ports: []v1.ServicePort{
+									{
+										Port: 20014,
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: Results{
+				DidPass: true,
+				Message: "* Port found: 20014\n",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -146,7 +227,7 @@ func Test_inputs_GeneralCheck(t *testing.T) {
 				namespace:  tt.fields.namespace,
 			}
 			if got := i.GeneralCheck(tt.args.kubeClientSet); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("inputs.GeneralCheck() = %v, want %v", got, tt.want)
+				t.Errorf("%v: inputs.GeneralCheck() = %v, want %v", tt.name, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
I found this example and didnt know that this fake k8s object thing existed:  https://gianarb.it/blog/unit-testing-kubernetes-client-in-go

Looks super cool and it does exactly what you want it to do.  Which is to test out pulling back k8s info and running it through your functions.

https://gianarb.it/blog/unit-testing-kubernetes-client-in-go

So i added this into the first check.