### PR TITLE
Check number of containers

### DIFF
--- a/src/checks/kubernetes/deployments/deployment.go
+++ b/src/checks/kubernetes/deployments/deployment.go
@@ -106,7 +106,7 @@ func (i inputs) GeneralCheck(kubeClientSet kubernetes.Interface) Results {
 						if inputContainer.Name == container.Name {
 
 							// The number of envars that should exist
-							numberOfEnvars := len(container.Env)
+							numberOfEnvars := len(inputContainer.Env)
 							numberOfEnvarsFound := 0
 
 							// Find the envars in the k8s pod's containers

--- a/src/checks/kubernetes/deployments/deployment.go
+++ b/src/checks/kubernetes/deployments/deployment.go
@@ -120,12 +120,13 @@ func (i inputs) GeneralCheck(kubeClientSet kubernetes.Interface) Results {
 								}
 							}
 
-							if numberOfEnvars == numberOfEnvarsFound {
-								// Found the correct amount of envars
-								numberOfContainersEnvarsFound++
-								checkResult.Message += "* Found all envars in Deployment: " + values.Values.DeploymentName + " | container: " + container.Name + "\n"
+							if numberOfEnvars > 0 {
+								if numberOfEnvars == numberOfEnvarsFound {
+									// Found the correct amount of envars
+									numberOfContainersEnvarsFound++
+									checkResult.Message += "* Found all envars in Deployment: " + values.Values.DeploymentName + " | container: " + container.Name + "\n"
+								}
 							}
-
 						}
 					}
 				}

--- a/src/checks/kubernetes/deployments/deployment_test.go
+++ b/src/checks/kubernetes/deployments/deployment_test.go
@@ -118,6 +118,10 @@ values:
 														Name:  "foo2",
 														Value: "bar2",
 													},
+													{
+														Name:  "foo3",
+														Value: "bar3",
+													},
 												},
 											},
 											{

--- a/src/checks/kubernetes/deployments/deployment_test.go
+++ b/src/checks/kubernetes/deployments/deployment_test.go
@@ -144,6 +144,72 @@ values:
 `,
 			},
 		},
+		{
+			name: "Checking the number of pods in a deployment (positive)",
+			fields: fields{
+				checkName: "check1",
+				namespace: "ns1",
+				// The spacing is real finicky.  yaml can't have tabs.  All spacing must be spaces
+				valuesYaml: `---
+values:
+  # The service name to act on
+  deploymentName: check-number-of-pods
+  checksEnabled:
+    containers:
+    - name: pod-container1
+      containerMustBePresent: true
+    - name: pod-container2
+      containerMustBePresent: true`,
+			},
+			args: args{
+				// Doc/example: https://gianarb.it/blog/unit-testing-kubernetes-client-in-go
+				kubeClientSet: fake.NewSimpleClientset(&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "check-number-of-pods",
+								Namespace:   "ns1",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name: "pod-container1",
+												Env: []corev1.EnvVar{
+													{
+														Name:  "pod",
+														Value: "bar",
+													},
+													{
+														Name:  "pod",
+														Value: "bar2",
+													},
+												},
+											},
+											{
+												Name: "pod-container2",
+												Env: []corev1.EnvVar{
+													{
+														Name:  "pod",
+														Value: "bar",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: Results{
+				DidPass: true,
+				Message: `* Found the correct number of containers in this deployment`,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/checks/kubernetes/deployments/deployment_test.go
+++ b/src/checks/kubernetes/deployments/deployment_test.go
@@ -145,6 +145,7 @@ values:
 				DidPass: true,
 				Message: `* Found all envars in Deployment: deployment1 | container: container1
 * Found all envars in Deployment: deployment1 | container: container2
+* Found the correct number of containers in this deployment
 `,
 			},
 		},
@@ -161,9 +162,7 @@ values:
   checksEnabled:
     containers:
     - name: pod-container1
-      containerMustBePresent: true
-    - name: pod-container2
-      containerMustBePresent: true`,
+    - name: pod-container2`,
 			},
 			args: args{
 				// Doc/example: https://gianarb.it/blog/unit-testing-kubernetes-client-in-go
@@ -211,7 +210,8 @@ values:
 			},
 			want: Results{
 				DidPass: true,
-				Message: `* Found the correct number of containers in this deployment`,
+				Message: `* Found the correct number of containers in this deployment
+`,
 			},
 		},
 	}

--- a/src/checks/kubernetes/deployments/deployment_test.go
+++ b/src/checks/kubernetes/deployments/deployment_test.go
@@ -214,6 +214,136 @@ values:
 `,
 			},
 		},
+		{
+			name: "Checking the number of pods in a deployment 2 (positive)",
+			fields: fields{
+				checkName: "check1",
+				namespace: "ns1",
+				// The spacing is real finicky.  yaml can't have tabs.  All spacing must be spaces
+				valuesYaml: `---
+values:
+  # The service name to act on
+  deploymentName: check-number-of-pods
+  checksEnabled:
+    containers:
+    - name: pod-container1
+    - name: pod-container2`,
+			},
+			args: args{
+				// Doc/example: https://gianarb.it/blog/unit-testing-kubernetes-client-in-go
+				kubeClientSet: fake.NewSimpleClientset(&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "check-number-of-pods",
+								Namespace:   "ns1",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name: "pod-container1",
+												Env: []corev1.EnvVar{
+													{
+														Name:  "pod",
+														Value: "bar",
+													},
+													{
+														Name:  "pod",
+														Value: "bar2",
+													},
+												},
+											},
+											{
+												Name: "pod-container2",
+												Env: []corev1.EnvVar{
+													{
+														Name:  "pod",
+														Value: "bar",
+													},
+												},
+											},
+											// THis test has more pods in the deployments than what the user is looking for
+											{
+												Name: "pod-container3",
+												Env: []corev1.EnvVar{
+													{
+														Name:  "pod",
+														Value: "bar",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: Results{
+				DidPass: true,
+				Message: `* Found the correct number of containers in this deployment
+`,
+			},
+		},
+		{
+			name: "Checking the number of pods in a deployment 1 (negative)",
+			fields: fields{
+				checkName: "check1",
+				namespace: "ns1",
+				// The spacing is real finicky.  yaml can't have tabs.  All spacing must be spaces
+				valuesYaml: `---
+values:
+  # The service name to act on
+  deploymentName: check-number-of-pods
+  checksEnabled:
+    containers:
+    - name: pod-container1
+    - name: pod-container2`,
+			},
+			args: args{
+				// Doc/example: https://gianarb.it/blog/unit-testing-kubernetes-client-in-go
+				kubeClientSet: fake.NewSimpleClientset(&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "check-number-of-pods",
+								Namespace:   "ns1",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name: "pod-container1",
+												Env: []corev1.EnvVar{
+													{
+														Name:  "pod",
+														Value: "bar",
+													},
+													{
+														Name:  "pod",
+														Value: "bar2",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: Results{
+				DidPass: false,
+				Message: "",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/cmd/conf.yaml
+++ b/src/cmd/conf.yaml
@@ -3,25 +3,25 @@ some: other configs
 random: 5
 
 kubernetes-state-checker:
-# - ttype: serviceChecks
-#   name: Checks for various aspects of a service
-#   description: Allows you to check for various aspects of a service
-#   namespace: hos-m2
-#   # Input values for this specific check
-#   values:
-#     # The service name to act on
-#     serviceName: healthapp-caregaps
-#     # Port number to check if the `ports` check is enabled
-#     port: 20014
-#     checksEnabled:
-#       # Check if there is a cluster IP associated with this endpoint
-#       clusterIP: true
-#       # Checks if there are endpoints associated to this service or not
-#       endpoints: true
-#       # Check if host port is enabled or not
-#       hostPort: false
-#       # Check if the port is the one that is specified above
-#       ports: true
+- ttype: serviceChecks
+  name: Checks for various aspects of a service
+  description: Allows you to check for various aspects of a service
+  namespace: hos-m2
+  # Input values for this specific check
+  values:
+    # The service name to act on
+    serviceName: healthapp-caregaps
+    # Port number to check if the `ports` check is enabled
+    port: 20014
+    checksEnabled:
+      # Check if there is a cluster IP associated with this endpoint
+      clusterIP: true
+      # Checks if there are endpoints associated to this service or not
+      endpoints: true
+      # Check if host port is enabled or not
+      hostPort: false
+      # Check if the port is the one that is specified above
+      ports: true
 - ttype: deploymentChecks
   name: Checks for various aspects of a deployment
   description: Allows you to check for various aspects of a deployment
@@ -46,19 +46,19 @@ kubernetes-state-checker:
       configMapMounts:
       - foo
       - bar
-# - ttype: deploymentChecks
-#   name: Checks that the deployment has 2 contianers
-#   description: Allows you to check for various aspects of a deployment
-#   namespace: hos-m2
-#   # Input values for this specific check
-#   values:
-#     # The service name to act on
-#     deploymentName: healthapp-caregaps
-#     checksEnabled:
-#       containers:
-#       - name: healthapp-caregaps-app
-#         containerMustBePresent: true
-#       - name: envoy
-#         containerMustBePresent: true
-#       - name: opa
-#         containerMustBePresent: true
+- ttype: deploymentChecks
+  name: Checks that the deployment has 2 contianers
+  description: Allows you to check for various aspects of a deployment
+  namespace: hos-m2
+  # Input values for this specific check
+  values:
+    # The service name to act on
+    deploymentName: healthapp-caregaps
+    checksEnabled:
+      containers:
+      - name: healthapp-caregaps-app
+        containerMustBePresent: true
+      - name: envoy
+        containerMustBePresent: true
+      - name: opa
+        containerMustBePresent: true

--- a/src/cmd/conf.yaml
+++ b/src/cmd/conf.yaml
@@ -3,25 +3,25 @@ some: other configs
 random: 5
 
 kubernetes-state-checker:
-- ttype: serviceChecks
-  name: Checks for various aspects of a service
-  description: Allows you to check for various aspects of a service
-  namespace: hos-m2
-  # Input values for this specific check
-  values:
-    # The service name to act on
-    serviceName: healthapp-caregaps
-    # Port number to check if the `ports` check is enabled
-    port: 20014
-    checksEnabled:
-      # Check if there is a cluster IP associated with this endpoint
-      clusterIP: true
-      # Checks if there are endpoints associated to this service or not
-      endpoints: true
-      # Check if host port is enabled or not
-      hostPort: false
-      # Check if the port is the one that is specified above
-      ports: true
+# - ttype: serviceChecks
+#   name: Checks for various aspects of a service
+#   description: Allows you to check for various aspects of a service
+#   namespace: hos-m2
+#   # Input values for this specific check
+#   values:
+#     # The service name to act on
+#     serviceName: healthapp-caregaps
+#     # Port number to check if the `ports` check is enabled
+#     port: 20014
+#     checksEnabled:
+#       # Check if there is a cluster IP associated with this endpoint
+#       clusterIP: true
+#       # Checks if there are endpoints associated to this service or not
+#       endpoints: true
+#       # Check if host port is enabled or not
+#       hostPort: false
+#       # Check if the port is the one that is specified above
+#       ports: true
 - ttype: deploymentChecks
   name: Checks for various aspects of a deployment
   description: Allows you to check for various aspects of a deployment
@@ -32,13 +32,11 @@ kubernetes-state-checker:
     deploymentName: healthapp-caregaps
     checksEnabled:
       containers:
-      - name: container1
+      - name: healthapp-caregaps-app
         # Check if a set of environment variables are present
         env:
-        - name: foo
-          value: bar
-        - name: foo2
-          value: bar2
+        - name: AUTH_ADDRESS
+          value: localhost:30004
         # image:
         #   name: "something*:*"
         # healthcheck:
@@ -48,19 +46,19 @@ kubernetes-state-checker:
       configMapMounts:
       - foo
       - bar
-- ttype: deploymentChecks
-  name: Checks that the deployment has 2 contianers
-  description: Allows you to check for various aspects of a deployment
-  namespace: hos-m2
-  # Input values for this specific check
-  values:
-    # The service name to act on
-    deploymentName: healthapp-caregaps
-    checksEnabled:
-      containers:
-      - name: healthapp-caregaps-app
-        containerMustBePresent: true
-      - name: envoy
-        containerMustBePresent: true
-      - name: opa
-        containerMustBePresent: true
+# - ttype: deploymentChecks
+#   name: Checks that the deployment has 2 contianers
+#   description: Allows you to check for various aspects of a deployment
+#   namespace: hos-m2
+#   # Input values for this specific check
+#   values:
+#     # The service name to act on
+#     deploymentName: healthapp-caregaps
+#     checksEnabled:
+#       containers:
+#       - name: healthapp-caregaps-app
+#         containerMustBePresent: true
+#       - name: envoy
+#         containerMustBePresent: true
+#       - name: opa
+#         containerMustBePresent: true

--- a/src/cmd/conf.yaml
+++ b/src/cmd/conf.yaml
@@ -47,7 +47,7 @@ kubernetes-state-checker:
       - foo
       - bar
 - ttype: deploymentChecks
-  name: Checks that the deployment has 2 contianers
+  name: Checks that the deployment has 3 contianers
   description: Allows you to check for various aspects of a deployment
   namespace: hos-m2
   # Input values for this specific check
@@ -57,8 +57,5 @@ kubernetes-state-checker:
     checksEnabled:
       containers:
       - name: healthapp-caregaps-app
-        containerMustBePresent: true
       - name: envoy
-        containerMustBePresent: true
       - name: opa
-        containerMustBePresent: true

--- a/src/cmd/conf.yaml
+++ b/src/cmd/conf.yaml
@@ -48,3 +48,19 @@ kubernetes-state-checker:
       configMapMounts:
       - foo
       - bar
+- ttype: deploymentChecks
+  name: Checks that the deployment has 2 contianers
+  description: Allows you to check for various aspects of a deployment
+  namespace: hos-m2
+  # Input values for this specific check
+  values:
+    # The service name to act on
+    deploymentName: healthapp-caregaps
+    checksEnabled:
+      containers:
+      - name: healthapp-caregaps-app
+        containerMustBePresent: true
+      - name: envoy
+        containerMustBePresent: true
+      - name: opa
+        containerMustBePresent: true


### PR DESCRIPTION
What this has:
* Adds in an input flag in the container to denote that this container must exist in the deployment:
```
    checksEnabled:
      containers:
      - name: healthapp-caregaps-app
```
* Fixed the envar check.  It was checking on the returned output instead of from the user input to determine if the number of envars were correct.  Also fixed the unit test to test for this case.
