### PR TITLE
Adding a proper output table

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ go get k8s.io/client-go/tools/clientcmd
 go get k8s.io/client-go/util/homedir
 go get github.com/evanphx/json-patch
 go get k8s.io/kube-openapi/pkg/util/proto
+go get github.com/olekukonko/tablewriter
 ```
 
 ## Kubeconfig

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"checker"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
 	"unsafe"
 
+	"github.com/olekukonko/tablewriter"
 	yaml "gopkg.in/yaml.v2"
 
 	"k8s.io/client-go/kubernetes"
@@ -66,6 +67,9 @@ func main() {
 	var c conf
 	c.getConf()
 
+	// Output data
+	outpuData := [][]string{}
+
 	for _, aCheck := range c.KubernetesStateChecker {
 
 		// convert to yaml
@@ -86,14 +90,19 @@ func main() {
 		)
 		results := chk.Run()
 
-		fmt.Println(fmt.Sprintf(`+----------------------+----------------------------------------------------------------------+------+-------------+
-	| Test Type          | Name                                                                 | Pass | Message     |
-	+----------------------+----------------------------------------------------------------------+------+-------------+
-	| %s | %s | %s | %s  |
-	+----------------------+----------------------------------------------------------------------+------+-------------+`,
-			aCheck.Ttype, c.KubernetesStateChecker[0].Name, strconv.FormatBool(results.DidPass), results.Message))
-
+		outpuData = append(outpuData, []string{aCheck.Ttype, c.KubernetesStateChecker[0].Name, strconv.FormatBool(results.DidPass), results.Message})
 	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Test Type", "Name", "Status", "Message"})
+	table.SetRowLine(true)
+	table.SetReflowDuringAutoWrap(false)
+	table.SetColWidth(100)
+
+	for _, v := range outpuData {
+		table.Append(v)
+	}
+	table.Render() // Send output
 
 }
 


### PR DESCRIPTION


```
+------------------+-----------------------------------------+--------+------------------------------------------------------------------------------------------+
|    TEST TYPE     |                  NAME                   | STATUS |                                         MESSAGE                                          |
+------------------+-----------------------------------------+--------+------------------------------------------------------------------------------------------+
| serviceChecks    | Checks for various aspects of a service | true   | * ClusterIP Found                                                                        |
|                  |                                         |        |                                                                                          |
|                  |                                         |        | * Endpoint found: 192.168.52.208                                                         |
|                  |                                         |        |                                                                                          |
|                  |                                         |        | * Port found: 20014                                                                      |
|                  |                                         |        |                                                                                          |
|                  |                                         |        |                                                                                          |
+------------------+-----------------------------------------+--------+------------------------------------------------------------------------------------------+
| deploymentChecks | Checks for various aspects of a service | true   | * Found all envars in Deployment: healthapp-caregaps | container: healthapp-caregaps-app |
|                  |                                         |        |                                                                                          |
|                  |                                         |        | * Found the correct number of containers in this deployment                              |
|                  |                                         |        |                                                                                          |
|                  |                                         |        |                                                                                          |
+------------------+-----------------------------------------+--------+------------------------------------------------------------------------------------------+
| deploymentChecks | Checks for various aspects of a service | true   | * Found the correct number of containers in this deployment                              |
|                  |                                         |        |                                                                                          |
|                  |                                         |        |                                                                                          |
+------------------+-----------------------------------------+--------+------------------------------------------------------------------------------------------+
| podChecks        | Checks for various aspects of a service | false  | * Pod healthapp-caregaps-7bcc4966d8-59ztm is in Running state                            |
|                  |                                         |        |                                                                                          |
|                  |                                         |        | * Pod healthapp-caregaps-b64dc7884-gc9rb is in Running state                             |
|                  |                                         |        |                                                                                          |
|                  |                                         |        | * Did not find pod: foo                                                                  |
|                  |                                         |        |                                                                                          |
|                  |                                         |        |                                                                                          |
+------------------+-----------------------------------------+--------+------------------------------------------------------------------------------------------+
```