### PR TITLE
Adding flags for namespace and config override

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -117,7 +117,6 @@ func main() {
 			fmt.Println("Setting from input flag")
 		}
 
-		fmt.Println("xxxx")
 		fmt.Println(namespace)
 
 		// Execute the check runner

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -117,7 +117,6 @@ func main() {
 			fmt.Println("Setting from input flag")
 		}
 
-		fmt.Println(namespace)
 
 		// Execute the check runner
 		chk := checker.New(

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
+var kubeNamespace string
+var kscConfig string
+
 type conf struct {
 	Some                   string          `yaml:"some"`
 	Random                 int64           `yaml:"random"`
@@ -29,11 +32,19 @@ type conf struct {
 
 func (c *conf) getConf() *conf {
 
-	configFileLocation := os.Getenv("KSC_CONFIG")
+	configFileLocation := ""
 
-	if configFileLocation == "" {
-		fmt.Println("ERROR: You must set the environment variable KSC_CONFIG which points to the input config file.")
-		os.Exit(1)
+	// Input config from CLI flags
+	if kscConfig != "" {
+		configFileLocation = kscConfig
+	} else {
+		// Input config file from environment variable
+		configFileLocation = os.Getenv("KSC_CONFIG")
+
+		if configFileLocation == "" {
+			fmt.Println("ERROR: You must set the environment variable KSC_CONFIG which points to the input config file.")
+			os.Exit(1)
+		}
 	}
 
 	yamlFile, err := ioutil.ReadFile(configFileLocation)
@@ -48,6 +59,16 @@ func (c *conf) getConf() *conf {
 	return c
 }
 
+func init() {
+	// kubernetes namespace override
+	flag.StringVar(&kubeNamespace, "namespace", "", "(optional) to override the namespace value in the input config file")
+	flag.StringVar(&kubeNamespace, "n", "", "(optional) to override the namespace value in the input config file")
+
+	// kubernetes-state-checker input config via cli flag
+	flag.StringVar(&kscConfig, "config", "", "(optional) a flag to set the config file.  Will override the environment variable KSC_CONFIG")
+	flag.StringVar(&kscConfig, "c", "", "(optional) a flag to set the config file.  Will override the environment variable KSC_CONFIG")
+}
+
 func main() {
 
 	// Get kubeconfig
@@ -58,6 +79,8 @@ func main() {
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
+
+	// Parse all flags
 	flag.Parse()
 
 	// use the current context in kubeconfig
@@ -87,6 +110,16 @@ func main() {
 			panic(err.Error())
 		}
 
+		// Use namespace override or not
+		namespace := aCheck.Namespace
+		if kubeNamespace != "" {
+			namespace = kubeNamespace
+			fmt.Println("Setting from input flag")
+		}
+
+		fmt.Println("xxxx")
+		fmt.Println(namespace)
+
 		// Execute the check runner
 		chk := checker.New(
 			BytesToString(valuesYaml),
@@ -94,7 +127,7 @@ func main() {
 			aCheck.Ttype,
 			aCheck.Name,
 			aCheck.Description,
-			aCheck.Namespace,
+			namespace,
 			aCheck.Values,
 		)
 		results := chk.Run()


### PR DESCRIPTION
## Adds flags for:
* Overriding the namespace in the config.  As i was trying to actually use this having the namespace hardcoded in the config was a problem and was not so great for testing.   Then i could almost imagine that you might have a dev namespace named something and if someone else wanted to use it, they would have to change all of the configs instead of just being able to input a flag when they run this.
* Overriding the config file input.  It already accepts an envar.  The cli input would override that as another convenience.

```
$ go run src/cmd/main.go -n hos-m2 -c /foo/bar --help
Usage of /tmp/go-build393433255/b001/exe/main:
  -c string
        (optional) a flag to set the config file.  Will override the environment variable KSC_CONFIG
  -config string
        (optional) a flag to set the config file.  Will override the environment variable KSC_CONFIG
  -kubeconfig string
        (optional) absolute path to the kubeconfig file (default "/home/vscode/.kube/config")
  -n string
        (optional) to override the namespace value in the input config file
  -namespace string
        (optional) to override the namespace value in the input config file
```