### PR TITLE
Fixing service check

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,10 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${workspaceFolder}/src/cmd/main.go"
+            "program": "${workspaceFolder}/src/cmd/main.go",
+            "env": {
+                "KSC_CONFIG": "/workspaces/kubernetes-state-checker/conf.sample.yaml"
+            }
         }
     ]
 }

--- a/src/checks/kubernetes/services/service.go
+++ b/src/checks/kubernetes/services/service.go
@@ -98,6 +98,7 @@ func (i inputs) GeneralCheck(kubeClientSet kubernetes.Interface) Results {
 
 				if values.Values.ChecksEnabled.ClusterIP {
 					if aService.Spec.ClusterIP == "" {
+						checkResult.DidPass = false
 						checkResult.Message += "* No ClusterIP Found\n"
 					} else {
 						checkResult.DidPass = true
@@ -121,13 +122,16 @@ func (i inputs) GeneralCheck(kubeClientSet kubernetes.Interface) Results {
 											checkResult.DidPass = true
 											checkResult.Message += "* Endpoint found: " + anAddress.IP + "\n"
 										} else {
+											checkResult.DidPass = false
 											checkResult.Message += "* No Endpoint found in the Subsets[0].Addresses[x].IP field\n"
 										}
 									}
 								} else {
+									checkResult.DidPass = false
 									checkResult.Message += "* No Endpoint found in the Subsets[0].Addresses list\n"
 								}
 							} else {
+								checkResult.DidPass = false
 								checkResult.Message += "* No Endpoint found in the subsets list\n"
 							}
 						}
@@ -141,6 +145,7 @@ func (i inputs) GeneralCheck(kubeClientSet kubernetes.Interface) Results {
 				if values.Values.ChecksEnabled.Ports {
 					for _, port := range aService.Spec.Ports {
 						if port.Port != values.Values.Port {
+							checkResult.DidPass = false
 							checkResult.Message += "* Port NOT found: " + fmt.Sprint(values.Values.Port) + "\n"
 						} else {
 							checkResult.DidPass = true

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -102,6 +102,8 @@ func main() {
 	// Output data
 	outpuData := [][]string{}
 
+	tmpCounter := 0
+
 	for _, aCheck := range c.KubernetesStateChecker {
 
 		// convert to yaml
@@ -117,7 +119,6 @@ func main() {
 			fmt.Println("Setting from input flag")
 		}
 
-
 		// Execute the check runner
 		chk := checker.New(
 			BytesToString(valuesYaml),
@@ -130,7 +131,9 @@ func main() {
 		)
 		results := chk.Run()
 
-		outpuData = append(outpuData, []string{aCheck.Ttype, c.KubernetesStateChecker[0].Name, strconv.FormatBool(results.DidPass), results.Message})
+		outpuData = append(outpuData, []string{aCheck.Ttype, c.KubernetesStateChecker[tmpCounter].Name, strconv.FormatBool(results.DidPass), results.Message})
+
+		tmpCounter++
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
Problem described here: https://anthemai.atlassian.net/browse/HSS-258

It was incorrectly setting a check to pass when it should have failed due to not explicitly setting the check to fail when there are multiple "checks" in one check.  If you wanted to check for ports, endpoints, etc...if one of them passed, it all passed even if a subsequent one failed.

Also adding a unit test to check for this condition.

